### PR TITLE
Refactor to use Dash Pages for main content

### DIFF
--- a/layout.py
+++ b/layout.py
@@ -1,5 +1,6 @@
 import json
 
+import dash
 import dash_bootstrap_components as dbc
 from dash import Dash, dcc, html
 
@@ -33,6 +34,7 @@ def create_app():
             }
         ],
         url_base_pathname=url_base_pathname,
+        use_pages=True,
     )
 
     app.layout = create_app_layout()
@@ -54,17 +56,6 @@ def create_app_layout():
 
     with open("./assets/markdown/user_guide.md", "r") as file:
         user_guide_markdown = file.read()
-
-    def create_donut_chart_column(figure_id):
-        donut_column = dbc.Col(
-            dbc.Card(
-                dcc.Loading(dbc.CardBody(dcc.Graph(id=figure_id))),
-                className="shadow-sm mb-4 bg-white rounded",
-            ),
-            sm=12,
-            lg=4,
-        )
-        return donut_column
 
     layout = html.Div(
         id="top-level-container",
@@ -102,72 +93,7 @@ def create_app_layout():
                 ],
                 className="d-flex align-items-center justify-content-between",
             ),
-            html.Div(
-                id="content-container",
-                children=[
-                    html.Div(
-                        id="date-picker-container",
-                        children=[
-                            html.Label(
-                                id="date-picker-label", children="Specify a Date Range"
-                            ),
-                            dcc.DatePickerRange(id="date-picker"),
-                        ],
-                    ),
-                    dbc.Row(
-                        children=[
-                            dbc.Col(
-                                dbc.Card(
-                                    dcc.Loading(
-                                        dbc.CardBody(
-                                            [
-                                                html.H5(
-                                                    "Total Number of Games",
-                                                    className="card-title",
-                                                ),
-                                                html.P(
-                                                    id="total-games-value",
-                                                    className="card-text",
-                                                ),
-                                            ]
-                                        )
-                                    ),
-                                    className="shadow-sm mb-4 bg-white rounded mt-4",
-                                    id="total-games-card",
-                                ),
-                                lg=2,
-                            ),
-                        ]
-                    ),
-                    html.Div(
-                        [
-                            html.Div(
-                                id="donut-charts-container",
-                                children=[
-                                    dbc.Row(
-                                        [
-                                            create_donut_chart_column(
-                                                "instance_version-chart"
-                                            ),
-                                            create_donut_chart_column("oos-chart"),
-                                            create_donut_chart_column("reload-chart"),
-                                        ]
-                                    ),
-                                    dbc.Row(
-                                        [
-                                            create_donut_chart_column(
-                                                "observers-chart"
-                                            ),
-                                            create_donut_chart_column("password-chart"),
-                                            create_donut_chart_column("public-chart"),
-                                        ]
-                                    ),
-                                ],
-                            ),
-                        ]
-                    ),
-                ],
-            ),
+            dash.page_container,
             html.Footer(
                 id="footer-container",
                 children=html.Div(

--- a/pages/aggregate_statistics.py
+++ b/pages/aggregate_statistics.py
@@ -4,7 +4,7 @@ from dash import html
 import dash_bootstrap_components as dbc
 from dash import dcc, html
 
-dash.register_page(__name__, path="/statistics")
+dash.register_page(__name__, path="/")
 
 
 def create_donut_chart_column(figure_id):

--- a/pages/aggregate_statistics.py
+++ b/pages/aggregate_statistics.py
@@ -1,0 +1,87 @@
+import dash
+from dash import html
+
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+dash.register_page(__name__, path="/statistics")
+
+
+def create_donut_chart_column(figure_id):
+    donut_column = dbc.Col(
+        dbc.Card(
+            dcc.Loading(dbc.CardBody(dcc.Graph(id=figure_id))),
+            className="shadow-sm mb-4 bg-white rounded",
+        ),
+        sm=12,
+        lg=4,
+    )
+    return donut_column
+
+
+layout = html.Div(
+    id="content-container",
+    children=[
+        html.Div(
+            id="date-picker-container",
+            children=[
+                html.Label(
+                    id="date-picker-label", children="Specify a Date Range"
+                ),
+                dcc.DatePickerRange(id="date-picker"),
+            ],
+        ),
+        dbc.Row(
+            children=[
+                dbc.Col(
+                    dbc.Card(
+                        dcc.Loading(
+                            dbc.CardBody(
+                                [
+                                    html.H5(
+                                        "Total Number of Games",
+                                        className="card-title",
+                                    ),
+                                    html.P(
+                                        id="total-games-value",
+                                        className="card-text",
+                                    ),
+                                ]
+                            )
+                        ),
+                        className="shadow-sm mb-4 bg-white rounded mt-4",
+                        id="total-games-card",
+                    ),
+                    lg=2,
+                ),
+            ]
+        ),
+        html.Div(
+            [
+                html.Div(
+                    id="donut-charts-container",
+                    children=[
+                        dbc.Row(
+                            [
+                                create_donut_chart_column(
+                                    "instance_version-chart"
+                                ),
+                                create_donut_chart_column("oos-chart"),
+                                create_donut_chart_column("reload-chart"),
+                            ]
+                        ),
+                        dbc.Row(
+                            [
+                                create_donut_chart_column(
+                                    "observers-chart"
+                                ),
+                                create_donut_chart_column("password-chart"),
+                                create_donut_chart_column("public-chart"),
+                            ]
+                        ),
+                    ],
+                ),
+            ]
+        ),
+    ],
+),


### PR DESCRIPTION
### Rationale

This is a necessary step so that additional pages can be added to the web application. Part of solving #8. The goal is to create another page containing a lot of the code from https://github.com/wesnoth/wesnoth-multiplayer-data-dashboard/tree/Table-and-Figures-Combined-early-build.

### Implementation

The code from the main content div has merely been transferred out into a new file `pages/aggregate_statistics.py` and, in `layout.py`, a `page_container` is used to display the main content.

### Relevant Documentation

See https://dash.plotly.com/urls