### PR TITLE
consolidate config

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,26 +22,10 @@ import pandas as pd
 import plotly.express as px
 from dash import Input, Output, State, callback
 from dash.exceptions import PreventUpdate
-from flask_caching import Cache
 
 from layout import create_app
 
 
-app = create_app()
-server = app.server
-
-# Set up Flask-Caching for sharing data between callbacks
-# Refer to the documentation for more information:
-# Dash documentation: https://dash.plotly.com/sharing-data-between-callbacks
-# Flask-Caching documentation: https://flask-caching.readthedocs.io/en/latest/
-CACHE_CONFIG = {
-    "CACHE_TYPE": "SimpleCache",  # SimpleCache stores cached data in memory as a Dictionary.
-}
-cache = Cache()
-cache.init_app(app.server, config=CACHE_CONFIG)
-
-
-@cache.memoize()
 def get_config_data():
     """Loads user-defined configuration options.
 
@@ -97,11 +81,16 @@ def get_config_data():
 
     logging.debug(
         "Loaded user-defined app configuration options."
-    )  # This only gets logged the first time the function is called and proves that memoization is functioning.
+    )
     return config
 
 
-def connect_to_mariadb():
+config = get_config_data()
+app = create_app(config["url_base_pathname"], config["query_row_limit"])
+server = app.server
+
+
+def connect_to_mariadb(config):
     """
     Connects to a MariaDB database using credentials from user-defined app configuration options.
 
@@ -112,7 +101,6 @@ def connect_to_mariadb():
     mariadb.Error: An error occurred while connecting to the database.
     """
     try:
-        config = get_config_data()
         connection = mariadb.connect(
             user=config["user"],
             password=config["password"],
@@ -157,9 +145,9 @@ def update_total_games_value(start_date, end_date):
         raise PreventUpdate
 
     # Fetch the total count of games played in the given date range from the database.
-    mariadb_connection = connect_to_mariadb()
+    mariadb_connection = connect_to_mariadb(config)
     cursor = mariadb_connection.cursor()
-    target_table = get_config_data()["table_names_map"]["game_info"]
+    target_table = config["table_names_map"]["game_info"]
     cursor.execute(
         f"SELECT COUNT(*) FROM {target_table} WHERE START_TIME BETWEEN ? AND ?",
         (start_date, end_date),
@@ -193,9 +181,9 @@ def update_instance_version_chart(start_date, end_date):
         return px.pie()  # An empty chart
 
     # Query the database.
-    mariadb_connection = connect_to_mariadb()
+    mariadb_connection = connect_to_mariadb(config)
     cursor = mariadb_connection.cursor()
-    target_table = get_config_data()["table_names_map"]["game_info"]
+    target_table = config["table_names_map"]["game_info"]
     cursor.execute(
         f"SELECT INSTANCE_VERSION, COUNT(*) FROM {target_table} WHERE START_TIME BETWEEN ? AND ? GROUP BY INSTANCE_VERSION",
         (start_date, end_date),
@@ -246,9 +234,9 @@ def update_oos_chart(start_date, end_date):
         return px.pie()  # An empty chart
 
     # Query the database.
-    mariadb_connection = connect_to_mariadb()
+    mariadb_connection = connect_to_mariadb(config)
     cursor = mariadb_connection.cursor()
-    target_table = get_config_data()["table_names_map"]["game_info"]
+    target_table = config["table_names_map"]["game_info"]
     cursor.execute(
         f"SELECT OOS, COUNT(*) FROM {target_table} WHERE START_TIME BETWEEN ? AND ? GROUP BY OOS",
         (start_date, end_date),
@@ -303,9 +291,9 @@ def update_reload_chart(start_date, end_date):
         return px.pie()  # An empty chart
 
     # Query the database.
-    mariadb_connection = connect_to_mariadb()
+    mariadb_connection = connect_to_mariadb(config)
     cursor = mariadb_connection.cursor()
-    target_table = get_config_data()["table_names_map"]["game_info"]
+    target_table = config["table_names_map"]["game_info"]
     cursor.execute(
         f"SELECT RELOAD, COUNT(*) FROM {target_table} WHERE START_TIME BETWEEN ? AND ? GROUP BY RELOAD",
         (start_date, end_date),
@@ -360,9 +348,9 @@ def update_observers_chart(start_date, end_date):
         return px.pie()  # An empty chart
 
     # Query the database.
-    mariadb_connection = connect_to_mariadb()
+    mariadb_connection = connect_to_mariadb(config)
     cursor = mariadb_connection.cursor()
-    target_table = get_config_data()["table_names_map"]["game_info"]
+    target_table = config["table_names_map"]["game_info"]
     cursor.execute(
         f"SELECT OBSERVERS, COUNT(*) FROM {target_table} WHERE START_TIME BETWEEN ? AND ? GROUP BY OBSERVERS",
         (start_date, end_date),
@@ -417,9 +405,9 @@ def update_password_chart(start_date, end_date):
         return px.pie()  # An empty chart
 
     # Query the database.
-    mariadb_connection = connect_to_mariadb()
+    mariadb_connection = connect_to_mariadb(config)
     cursor = mariadb_connection.cursor()
-    target_table = get_config_data()["table_names_map"]["game_info"]
+    target_table = config["table_names_map"]["game_info"]
     cursor.execute(
         f"SELECT PASSWORD, COUNT(*) FROM {target_table} WHERE START_TIME BETWEEN ? AND ? GROUP BY PASSWORD",
         (start_date, end_date),
@@ -474,9 +462,9 @@ def update_public_chart(start_date, end_date):
         return px.pie()  # An empty chart
 
     # Query the database.
-    mariadb_connection = connect_to_mariadb()
+    mariadb_connection = connect_to_mariadb(config)
     cursor = mariadb_connection.cursor()
-    target_table = get_config_data()["table_names_map"]["game_info"]
+    target_table = config["table_names_map"]["game_info"]
     cursor.execute(
         f"SELECT PUBLIC, COUNT(*) FROM {target_table} WHERE START_TIME BETWEEN ? AND ? GROUP BY PUBLIC",
         (start_date, end_date),
@@ -542,9 +530,9 @@ def update_total_games_value(start_date, end_date):
         raise PreventUpdate
 
     # Fetch the total count of games played in the given date range from the database.
-    mariadb_connection = connect_to_mariadb()
+    mariadb_connection = connect_to_mariadb(config)
     cursor = mariadb_connection.cursor()
-    target_table = get_config_data()["table_names_map"]["game_info"]
+    target_table = config["table_names_map"]["game_info"]
     cursor.execute(
         f"SELECT COUNT(*) FROM {target_table} WHERE START_TIME BETWEEN ? AND ?",
         (start_date, end_date),
@@ -580,15 +568,15 @@ def update_table(total_games, start_date, end_date):
     if start_date is None or end_date is None:
         raise PreventUpdate
 
-    query_row_limit = get_config_data().get("query_row_limit", 5000)
+    query_row_limit = config.get("query_row_limit", 5000)
 
     # Inform the user that the query cannot be processed because the size of the data to process exceeds limitations.
     if total_games > query_row_limit:
         return [], True
 
-    mariadb_connection = connect_to_mariadb()
+    mariadb_connection = connect_to_mariadb(config)
     cursor = mariadb_connection.cursor()
-    target_table = get_config_data()["table_names_map"]["game_info"]
+    target_table = config["table_names_map"]["game_info"]
     cursor.execute(
         f"SELECT * FROM {target_table} WHERE START_TIME BETWEEN ? AND ?",
         (start_date, end_date),

--- a/app.py
+++ b/app.py
@@ -43,7 +43,15 @@ cache.init_app(app.server, config=CACHE_CONFIG)
 
 @cache.memoize()
 def get_config_data():
-    """Fetches and returns data from the configuration options file as a dictionary."""
+    """Loads user-defined configuration options.
+
+    The function first sets default configurations.
+    Then, it tries to load configurations from a .json file.
+    Then, it tries to load configurations from environment variables.
+
+    Returns:
+    dict: A dictionary containing user-defined configuration options.
+    """
 
     # Set default configuration
     config = {

--- a/app.py
+++ b/app.py
@@ -57,8 +57,8 @@ def connect_to_mariadb():
     Connects to a MariaDB database using defaults, a .json file, or environment variables, for authentication.
 
     The function first sets default configuration.
-    Then it tries to load configuration from a .json file.
-    Then it tries to load configuration from environment variables.
+    Then, it tries to load configuration from a .json file.
+    Then, it tries to load configuration from environment variables.
     Finally, it tries to load configuration from command line parameters.
 
     Returns:

--- a/layout.py
+++ b/layout.py
@@ -5,27 +5,20 @@ import dash_bootstrap_components as dbc
 from dash import Dash, dcc, html
 
 
-def create_app():
+def create_app(url_base_pathname: str, query_row_limit: int) -> Dash:
     """
     Creates a Dash web application instance for the Wesnoth Multiplayer Dashboard.
 
     This function initializes a Dash web application instance with external stylesheets,
     meta tags, and a layout tailored for displaying Wesnoth multiplayer game data.
 
+    Args:
+        url_base_pathname (str): The base URL path for the Dash web application.
+        query_row_limit (int): The maximum number of rows that can be returned by a query to the database.
+
     Returns:
         Dash: A Dash web application instance.
     """
-
-    # This section redundantly reads from 'config.json' due to limitations in accessing configuration data.
-    # It's not feasible to use 'get_config_data()' from 'app.py' because it relies on flask-caching
-    # for memoization, which can only be set up after the 'app' object instantiation.
-    # Additionally, 'url_base_pathname' can only be set during app instantiation, not afterwards.
-    # Thus, we cannot instantiate 'app', set up flask-caching, fetch config data using the memoized
-    # 'get_config_data()', and then update 'url_base_pathname'.
-    with open("config.json", "r") as f:
-        config = json.load(f)
-        url_base_pathname = config["url_base_pathname"]
-        query_row_limit = config.get("query_row_limit", 5000)
 
     app = Dash(
         __name__,

--- a/layout.py
+++ b/layout.py
@@ -98,7 +98,7 @@ def create_app_layout(query_row_limit, url_base_pathname):
                                 id="modal",
                                 is_open=False,
                                 size="xl",
-                            ),                            
+                            ),
                         ],
                         className="d-flex align-items-center justify-content-between",
                     ),
@@ -108,12 +108,18 @@ def create_app_layout(query_row_limit, url_base_pathname):
                             html.Ul(
                                 id="nav-list",
                                 children=[
-                                    html.Li(dcc.Link("Statistics", href=url_base_pathname)),
-                                    html.Li(dcc.Link("Query", href=f"{url_base_pathname}query")),
-                                ]
+                                    html.Li(
+                                        dcc.Link("Statistics", href=url_base_pathname)
+                                    ),
+                                    html.Li(
+                                        dcc.Link(
+                                            "Query", href=f"{url_base_pathname}query"
+                                        )
+                                    ),
+                                ],
                             )
                         ],
-                    )
+                    ),
                 ],
             ),
             dash.page_container,
@@ -145,7 +151,9 @@ def create_app_layout(query_row_limit, url_base_pathname):
             dbc.Modal(
                 [
                     dbc.ModalHeader(dbc.ModalTitle("Query size Too Large")),
-                    dbc.ModalBody(f"Due to server hardware constraints, the maximum query output size has been limited to {query_row_limit} total games. Please reduce the range of your query."),
+                    dbc.ModalBody(
+                        f"Due to server hardware constraints, the maximum query output size has been limited to {query_row_limit} total games. Please reduce the range of your query."
+                    ),
                 ],
                 id="constraints-modal",
                 is_open=False,

--- a/layout.py
+++ b/layout.py
@@ -16,6 +16,12 @@ def create_app():
         Dash: A Dash web application instance.
     """
 
+    # This section redundantly reads from 'config.json' due to limitations in accessing configuration data.
+    # It's not feasible to use 'get_config_data()' from 'app.py' because it relies on flask-caching
+    # for memoization, which can only be set up after the 'app' object instantiation.
+    # Additionally, 'url_base_pathname' can only be set during app instantiation, not afterwards.
+    # Thus, we cannot instantiate 'app', set up flask-caching, fetch config data using the memoized
+    # 'get_config_data()', and then update 'url_base_pathname'.
     with open("config.json", "r") as f:
         config = json.load(f)
         url_base_pathname = config["url_base_pathname"]

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -2,4 +2,3 @@ dash
 dash-bootstrap-components
 mariadb
 pandas
-Flask-Caching


### PR DESCRIPTION
closes #16

All the loading of `config.json` inside of `app.py` is consolidated. However, there is a loading of `config.json` inside of `layout.py` that seems to be unavoidable because the keyword arguments of the Dash app object constructor can only be passed during object instantiation and not updated post-object-instantiation. I wrote a comment for any future devs to understand the reasoning. I think this is something we can easily live with.